### PR TITLE
Misc fixes

### DIFF
--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_misc.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_misc.py
@@ -431,9 +431,12 @@ def attach_to_cli(cli):
         not_reg_keys = []
         for key, val in subject.items():
             if isinstance(val, dict):
-                if len(val.get('value')) == 0:
+                if val.get('value') is None:
                     not_reg_keys.append(key)
-        warnings.warn('No value registered for {}'.format(not_reg_keys))
+                elif len(val.get('value')) == 0:
+                    not_reg_keys.append(key)
+        if len(not_reg_keys) > 0:
+            warnings.warn('No value registered for {}'.format(not_reg_keys))
         action.require_module(name=subject_template_name, contents=subject,
                               overwrite=True)
 

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -71,10 +71,18 @@ def attach_to_cli(cli):
                   is_flag=True,
                   help='Not run klusta on dataset.',
                   )
-    @click.option('--no-convert',
+    @click.option('--no-spikes',
                   is_flag=True,
-                  help='Not convert to exdir.',
+                  help='Disable convertion of spikes to exdir.',
                   )
+    @click.option('--no-lfp',
+                  is_flag=True,
+                  help='Disable convertion of LFP to exdir.',
+                  )
+    @click.option('--no-tracking',
+                  is_flag=True,
+                  help='Disable registering of tracking data to exdir.',
+                  )    
     @click.option('--no-local',
                   is_flag=True,
                   help='Store temporary on local drive.',
@@ -88,16 +96,12 @@ def attach_to_cli(cli):
                   default=0,
                   help='TTL channel for shutter events to sync tracking',
                   )
-    @click.option('--no-tracking',
-                  is_flag=True,
-                  help='Disable registering of tracking data',
-                  )
     def process_openephys(action_id, prb_path, pre_filter,
                           klusta_filter, filter_low,
                           filter_high, nchan, common_ref, ground,
                           split_probe, no_local, openephys_path,
-                          exdir_path, no_klusta, no_convert, shutter_channel,
-                          no_preprocess, no_tracking):
+                          exdir_path, no_klusta, shutter_channel,
+                          no_preprocess, no_spikes, no_lfp, no_tracking):
         settings = config.load_settings()['current']
         if not no_klusta:
             import klusta
@@ -181,28 +185,27 @@ def attach_to_cli(cli):
                 subprocess.check_output(['klusta', klusta_prm, '--overwrite'])
             except subprocess.CalledProcessError as e:
                 raise Exception(e.output)
-        if not no_convert:
-            print('Converting to exdir')
+        if not no_spikes:
+            print('Converting from ".kwik" to ".exdir"')
             openephys.generate_spike_trains(exdir_path, openephys_file,
                                             source='klusta')
-            print('Finished with spiketrains, you can now start manual ' +
-                  'clustering while tracking and LFP is processed')
+            print('Processed spiketrains, manual clustering possible')
+        if not no_lfp:
+            print('Filtering and downsampling raw data to LFP.')
+            openephys.generate_lfp(exdir_path, openephys_file)
+            print('Finished processing LFPs.')
+        if not no_tracking:
+            print('Converting tracking from OpenEphys raw data to ".exdir"')
+            openephys.generate_tracking(exdir_path, openephys_file)
             if shutter_channel is not None:
-                ttl_times = openephys_file.digital_in_signals[0].times[shutter_channel]
+                ttl_times = openephys_file.digital_in_signals[0].times[
+                    shutter_channel]
                 if len(ttl_times) != 0:
                     openephys_file.sync_tracking_from_events(ttl_times)
                 else:
-                    warnings.warn(
-                        'No TTL events was found on IO channel {}'.format(shutter_channel)
-                    )
-            openephys.generate_lfp(exdir_path, openephys_file)
-        if no_tracking and no_convert:
-            warnings.warn('Option no-tracking = {} has no effect as option no_convert = {}'.format(
-                no_tracking, no_convert)) 
-        elif not no_tracking and not no_convert:
-            openephys.generate_tracking(exdir_path, openephys_file)
-        else:
-            pass
+                    warnings.warn('No TTL events found on IO channel {}'.format(
+                        shutter_channel))
+
 
     @cli.command('register',
                  short_help='Generate an open-ephys recording-action to database.')

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -390,7 +390,10 @@ def attach_to_cli(cli):
                 openephys.generate_spike_trains(exdir_path, openephys_file,
                                                 source=spikes_source)
             if not no_move:
-                shutil.rmtree(openephys_path)
+                if action_tools.query_yes_no(
+                    'Delete raw data in {}? (yes/no)'.format(openephys_path),
+                    default='no'):
+                    shutil.rmtree(openephys_path)
 
     @cli.command('convert-klusta-oe',
                  short_help='Convert klusta spikes to exdir.')

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -81,7 +81,7 @@ def attach_to_cli(cli):
                   )
     @click.option('--no-preprocess',
                   is_flag=True,
-                  help='Preporcess data.',
+                  help='Preprocess data.',
                   )
     @click.option('--shutter-channel',
                   type=click.INT,
@@ -126,7 +126,7 @@ def attach_to_cli(cli):
                 raise IOError('Choose either klusta-filter or pre-filter.')
             anas = openephys_file.analog_signals[0].signal
             fs = openephys_file.sample_rate.magnitude
-            nchan = anas.shape[0]
+            #nchan = anas.shape[0]
             sig_tools.create_klusta_prm(openephys_base, prb_path, nchan,
                               fs=fs, klusta_filter=klusta_filter,
                               filter_low=filter_low,
@@ -191,7 +191,7 @@ def attach_to_cli(cli):
                     warnings.warn(
                         'No TTL events was found on IO channel {}'.format(shutter_channel)
                     )
-            openephys.generate_tracking(exdir_path, openephys_file)
+            #openephys.generate_tracking(exdir_path, openephys_file)
             openephys.generate_lfp(exdir_path, openephys_file)
 
     @cli.command('register',
@@ -329,7 +329,7 @@ def attach_to_cli(cli):
             raise ValueError('Please add user name')
         print('Registering user ' + user)
         action.users = [user]
-        location = location or PAR.USER_PARAMS('location')
+        location = location or PAR.USER_PARAMS['location']
         location = location or []
         if len(location) == 0:
             raise ValueError('Please add location')

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -196,8 +196,8 @@ def attach_to_cli(cli):
                         'No TTL events was found on IO channel {}'.format(shutter_channel)
                     )
             openephys.generate_lfp(exdir_path, openephys_file)
-        if not no_tracking and no_convert:
-            warnings.warn('option no-tracking = {} has no effect as option no_convert = {}'.format(
+        if no_tracking and no_convert:
+            warnings.warn('Option no-tracking = {} has no effect as option no_convert = {}'.format(
                 no_tracking, no_convert)) 
         elif not no_tracking and not no_convert:
             openephys.generate_tracking(exdir_path, openephys_file)

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -88,12 +88,16 @@ def attach_to_cli(cli):
                   default=0,
                   help='TTL channel for shutter events to sync tracking',
                   )
+    @click.option('--no-tracking',
+                  is_flag=True,
+                  help='Disable registering of tracking data',
+                  )
     def process_openephys(action_id, prb_path, pre_filter,
                           klusta_filter, filter_low,
                           filter_high, nchan, common_ref, ground,
                           split_probe, no_local, openephys_path,
                           exdir_path, no_klusta, no_convert, shutter_channel,
-                          no_preprocess):
+                          no_preprocess, no_tracking):
         settings = config.load_settings()['current']
         if not no_klusta:
             import klusta
@@ -126,7 +130,7 @@ def attach_to_cli(cli):
                 raise IOError('Choose either klusta-filter or pre-filter.')
             anas = openephys_file.analog_signals[0].signal
             fs = openephys_file.sample_rate.magnitude
-            #nchan = anas.shape[0]
+            nchan = anas.shape[0]
             sig_tools.create_klusta_prm(openephys_base, prb_path, nchan,
                               fs=fs, klusta_filter=klusta_filter,
                               filter_low=filter_low,
@@ -191,7 +195,8 @@ def attach_to_cli(cli):
                     warnings.warn(
                         'No TTL events was found on IO channel {}'.format(shutter_channel)
                     )
-            #openephys.generate_tracking(exdir_path, openephys_file)
+            if not no_tracking:
+                openephys.generate_tracking(exdir_path, openephys_file)
             openephys.generate_lfp(exdir_path, openephys_file)
 
     @cli.command('register',

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -195,9 +195,14 @@ def attach_to_cli(cli):
                     warnings.warn(
                         'No TTL events was found on IO channel {}'.format(shutter_channel)
                     )
-            if not no_tracking:
-                openephys.generate_tracking(exdir_path, openephys_file)
             openephys.generate_lfp(exdir_path, openephys_file)
+        if not no_tracking and no_convert:
+            warnings.warn('option no-tracking = {} has no effect as option no_convert = {}'.format(
+                no_tracking, no_convert)) 
+        elif not no_tracking and not no_convert:
+            openephys.generate_tracking(exdir_path, openephys_file)
+        else:
+            pass
 
     @cli.command('register',
                  short_help='Generate an open-ephys recording-action to database.')

--- a/phy-contrib/phycontrib/neo/gui.py
+++ b/phy-contrib/phycontrib/neo/gui.py
@@ -77,8 +77,8 @@ def _get_distance_max(pos):
 class NeoController(EventEmitter):
     gui_name = 'NeoGUI'
 
-    n_spikes_waveforms = 100
-    batch_size_waveforms = 100
+    n_spikes_waveforms = 200
+    batch_size_waveforms = 200
 
     n_spikes_features = 10000
     n_spikes_amplitudes = 10000
@@ -223,6 +223,7 @@ class NeoController(EventEmitter):
         return Bunch(data=data,
                      channel_ids=channel_ids,
                      channel_positions=pos[channel_ids],
+                     alpha=0.25
                      )
 
     def _get_mean_waveforms(self, cluster_id):

--- a/phy-contrib/phycontrib/neo/gui.py
+++ b/phy-contrib/phycontrib/neo/gui.py
@@ -109,7 +109,7 @@ class NeoController(EventEmitter):
 
     def _set_cache(self):
         memcached = ('get_best_channels',
-                     'get_probe_depth',
+                     #'get_probe_depth',
                      '_get_mean_waveforms',
                      )
         cached = ('_get_waveforms',

--- a/phy-contrib/phycontrib/neo/gui.py
+++ b/phy-contrib/phycontrib/neo/gui.py
@@ -173,37 +173,31 @@ class NeoController(EventEmitter):
 
     def get_best_channel(self, cluster_id):
         channel_ids = self.get_best_channels(cluster_id)
-        amps = self.model.amplitudes.mean(axis=0)
-        channel_id = np.argmax(amps)
+        amps = self._get_mean_waveforms(cluster_id).data[0].min(axis=0)
+        channel_id = channel_ids[np.argmin(amps)]
         return channel_id
 
     def get_best_channels(self, cluster_ids):  # TODO
-        # mm = self._get_mean_waveforms(cluster_id)
-        # channel_ids = np.argsort(mm)[::-1]
-        # channel_ids = channel_ids[mm[channel_ids] > .1]
-        # return channel_ids
         return np.arange(self.model.n_chans)
 
     def get_cluster_position(self, cluster_id):
-        channel_id = self.get_best_channels(cluster_id)[0]
+        channel_id = self.get_best_channel(cluster_id)
         return self.model.channel_positions[channel_id]
 
     def get_probe_depth(self, cluster_id):
-        return self.get_cluster_position(cluster_id)[1]
+        channel_id = self.get_best_channel(cluster_id)
+        return self.model.channel_positions[channel_id][1]
 
     def similarity(self, cluster_id):
         """Return the list of similar clusters to a given cluster."""
 
         pos_i = self.get_cluster_position(cluster_id)
-        assert len(pos_i) == 2
-
+        
         def _sim_ij(cj):
             """Distance between channel position of clusters i and j."""
             pos_j = self.get_cluster_position(cj)
-            assert len(pos_j) == 2
             d = np.sqrt(np.sum((pos_j - pos_i) ** 2))
             return self.distance_max - d
-
         out = [(cj, _sim_ij(cj))
                for cj in self.supervisor.clustering.cluster_ids]
         return sorted(out, key=itemgetter(1), reverse=True)


### PR DESCRIPTION
Adds `no-tracking` option to `expipe openephys process` action for experiments that do not have tracking info, plus misc fixes, as discussed in Issue #2 