### PR TITLE
Filter options

### DIFF
--- a/exana/exana/misc/signal_tools.py
+++ b/exana/exana/misc/signal_tools.py
@@ -288,7 +288,7 @@ def filter_analog_signals(anas, freq, fs, filter_type='bandpass', filter_functio
     b, a = butter(order, band, btype=filter_type)
 
     if np.all(np.abs(np.roots(a)) < 1) and np.all(np.abs(np.roots(a)) < 1):
-        print('Filtering signals using', filter_function, 'with order', order, filter_type, 'filter cutoff(s) at' , freq ,'...')
+        print('Filtering signals using', filter_function, 'with order', order, filter_type, 'with critical frequencies', freq ,'...')
         if len(anas.shape) == 2:
             anas_filt = filterfun(b, a, anas, axis=1)
         elif len(anas.shape) == 1:
@@ -439,7 +439,7 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
                   high cutoff frequency (if klusta_filter is True)
     filter_order : int
         Butterworth filter order, default is 3.
-    
+
     Returns
     -------
     full_filename : absolute path of .prm file
@@ -469,7 +469,7 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
                 "\n\tuse_single_threshold=False,"
                 "\n\tthreshold_strong_std_factor=4,\n\tthreshold_weak_std_factor=2,\n\tdetect_spikes='negative',"
                 "\n\n\tconnected_component_join_size=1,\n"
-                "\n\textract_s_before=16,\n\textract_s_after=48,\n"
+                "\n\textract_s_before=16,\n\textract_s_after=64,\n"
                 "\n\tn_features_per_channel=3,\n\tpca_n_waveforms_max=10000,\n)")
         f.write('\n')
         f.write('\n')

--- a/exana/exana/misc/signal_tools.py
+++ b/exana/exana/misc/signal_tools.py
@@ -470,7 +470,7 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
                 "\n\tn_features_per_channel=3,\n\tpca_n_waveforms_max=10000,\n)")
         f.write('\n')
         f.write('\n')
-        f.write("klustakwik2 = dict(\n\tnum_starting_clusters=50,\n\tnum_cpus=4\n)")
+        f.write("klustakwik2 = dict(\n\tnum_starting_clusters=50,\n\tnum_cpus=8\n)")
                 # "\n\tnum_cpus=4,)")
     return full_filename
 

--- a/exana/exana/misc/signal_tools.py
+++ b/exana/exana/misc/signal_tools.py
@@ -437,6 +437,9 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
                 low cutoff frequency (if klusta_filter is True)
     filter_high : float
                   high cutoff frequency (if klusta_filter is True)
+    filter_order : int
+        Butterworth filter order, default is 3.
+    
     Returns
     -------
     full_filename : absolute path of .prm file

--- a/exana/exana/misc/signal_tools.py
+++ b/exana/exana/misc/signal_tools.py
@@ -418,7 +418,10 @@ def save_binary_format(filename, signal, spikesorter='klusta'):
 
 def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
                       klusta_filter=True, filter_low=300, filter_high=6000,
-                      filter_order=3):
+                      filter_order=3,
+                      use_single_threshold=True,
+                      threshold_strong_std_factor=4.5,
+                      threshold_weak_std_factor=2):
     """Creates klusta .prm files, with spikesorting parameters
 
     Parameters
@@ -466,8 +469,10 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
                     "\n\tfilter_butter_order="+str(filter_order)+",\n\tfilter_lfp_low=0,\n\tfilter_lfp_high=300,\n")
         f.write("\n\tchunk_size_seconds=1,\n\tchunk_overlap_seconds=.015,\n"
                 "\n\tn_excerpts=50,\n\texcerpt_size_seconds=1,"
-                "\n\tuse_single_threshold=False,"
-                "\n\tthreshold_strong_std_factor=4.5,\n\tthreshold_weak_std_factor=2,\n\tdetect_spikes='negative',"
+                "\n\tuse_single_threshold=" + str(use_single_threshold) +","
+                "\n\tthreshold_strong_std_factor=" + str(threshold_strong_std_factor) + ",\n"
+                "\tthreshold_weak_std_factor=" + str(threshold_weak_std_factor) + ",\n"
+                "\tdetect_spikes='negative',"
                 "\n\n\tconnected_component_join_size=1,\n"
                 "\n\textract_s_before=16,\n\textract_s_after=48,\n"
                 "\n\tn_features_per_channel=3,\n\tpca_n_waveforms_max=10000,\n)")

--- a/exana/exana/misc/signal_tools.py
+++ b/exana/exana/misc/signal_tools.py
@@ -7,12 +7,12 @@ import quantities as pq
 
 def auto_denoise(anas, thresh=None, copy_signal=True):
     """Clean neural data from EMG, chewing, and moving artifact noise
-    Rectified signals are smoothed and thresholded to find and remove 
+    Rectified signals are smoothed and thresholded to find and remove
     noisy portion of the signals.
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     thresh : float
              (optional) threshold in number of SD on high-pass data
@@ -29,7 +29,7 @@ def auto_denoise(anas, thresh=None, copy_signal=True):
         thresh = thresh
     else:
         thresh = 2.5
-    
+
     if copy_anas:
         anas_copy = copy(anas)
     else:
@@ -63,7 +63,7 @@ def manual_denoise(anas, thresh=None, copy_signal=True):
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     thresh : float
              (optional) threshold in number of SD on high-pass data
@@ -72,7 +72,7 @@ def manual_denoise(anas, thresh=None, copy_signal=True):
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     thresh : float
              (optional) threshold in number of SD on high-pass data
@@ -108,18 +108,18 @@ def manual_denoise(anas, thresh=None, copy_signal=True):
     return anas_copy
 
 def ica_denoise(anas, channels=None, n_comp=10, correlation_thresh=0.1):
-    """Removes noise by ICA. Indepentend components highly correlated to the 
+    """Removes noise by ICA. Indepentend components highly correlated to the
     grand average of the signals are removed.
     Signals are then back projected to the channel space.
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     channels : list
                list of good channels to perform ICA with
     n_comp : int
-             number of ICA components 
+             number of ICA components
     correlation_tresh : float
                         correlation threshold between average signal
                         and source above which source contibution gets
@@ -167,7 +167,7 @@ def apply_CAR(anas, channels=None, car_type='mean', split_probe=None, copy_signa
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     channels : list
                list of good channels to perform CAR/CMR with
@@ -222,7 +222,7 @@ def extract_rising_edges(adc_signal, times, thresh=1.65):
 
     Parameters
     ----------
-    adc_signal : np.array 
+    adc_signal : np.array
                  1d array of analog TTL signal
     times : np.array
             timestamps array
@@ -253,7 +253,7 @@ def filter_analog_signals(anas, freq, fs, filter_type='bandpass', filter_functio
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     freq : list or float
            cutoff frequency-ies in Hz
@@ -302,7 +302,7 @@ def ground_bad_channels(anas, bad_channels, copy_signal=True):
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     bad_channels : list
                    list of channels to be grounded
@@ -332,12 +332,12 @@ def ground_bad_channels(anas, bad_channels, copy_signal=True):
 
 
 def duplicate_bad_channels(anas, bad_channels, probefile, copy_signal=True):
-    """Duplicate selected noisy channels with channels in 
+    """Duplicate selected noisy channels with channels in
     the same channel group.
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     bad_channels : list
                    list of channels to be grounded
@@ -396,7 +396,7 @@ def save_binary_format(filename, signal, spikesorter='klusta'):
     ----------
     filename : string
                absolute path (_klusta.dat or _spycircus.dat are appended)
-    signal : np.array 
+    signal : np.array
              2d array of analog signals
     spikesorter : string
                   'klusta' or 'spykingcircus'
@@ -425,7 +425,7 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
     ----------
     pathname : string
                absolute path (_klusta.dat or _spycircus.dat are appended)
-    prbpath : np.array 
+    prbpath : np.array
               2d array of analog signals
     nchan : int
             number of channels
@@ -464,7 +464,7 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
         f.write("\n\tchunk_size_seconds=1,\n\tchunk_overlap_seconds=.015,\n"
                 "\n\tn_excerpts=50,\n\texcerpt_size_seconds=1,"
                 "\n\tuse_single_threshold=False,"
-                "\n\tthreshold_strong_std_factor=4.5,\n\tthreshold_weak_std_factor=2,\n\tdetect_spikes='negative',"
+                "\n\tthreshold_strong_std_factor=4,\n\tthreshold_weak_std_factor=2,\n\tdetect_spikes='negative',"
                 "\n\n\tconnected_component_join_size=1,\n"
                 "\n\textract_s_before=16,\n\textract_s_after=48,\n"
                 "\n\tn_features_per_channel=3,\n\tpca_n_waveforms_max=10000,\n)")
@@ -475,14 +475,14 @@ def create_klusta_prm(pathname, prb_path, nchan=32, fs=30000,
     return full_filename
 
 
-def remove_stimulation_artifacts(anas, times, trigger, pre=3 * pq.ms, post=5 * pq.ms, 
+def remove_stimulation_artifacts(anas, times, trigger, pre=3 * pq.ms, post=5 * pq.ms,
                                  mode='zero', copy_signal=True):
     """Removes stimulation artifact by either grounding the stimulation window or
     computing and removing the average artifact template.
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of analog signals
     times : quantity list
             timestamps
@@ -506,7 +506,7 @@ def remove_stimulation_artifacts(anas, times, trigger, pre=3 * pq.ms, post=5 * p
     if copy_signal:
         anas_rem = copy(anas)
     else:
-        anas_rem = anas       
+        anas_rem = anas
     print('Removing stimulation artifacts from ', len(trigger), ' triggers...')
 
     if mode is 'template':
@@ -545,13 +545,13 @@ def extract_stimulation_waveform(stim, trig, times):
 
     Parameters
     ----------
-    stim : np.array 
+    stim : np.array
            2d array of stimulation analog signals
     trigger : quantity list
               timestamps of stimulation triggers
     times : quantity list
             timestamps
-    
+
     Returns
     -------
     stim_clip : single stimulation pulse
@@ -608,9 +608,9 @@ def downsample_250(anas):
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of stimulation analog signals
-    
+
     Returns
     -------
     out : downsampled analog signals
@@ -639,7 +639,7 @@ def find_frequency_range(anas, fs, freq_range, nchunks=30, chunksize=1*pq.s):
 
     Parameters
     ----------
-    anas : np.array 
+    anas : np.array
            2d array of stimulation analog signals
     fs : quantity
          sampling frequency in Hz
@@ -647,9 +647,9 @@ def find_frequency_range(anas, fs, freq_range, nchunks=30, chunksize=1*pq.s):
                 freq boundaries to find peak in
     nchunks: int
              number of chunks used to compute spectra
-    chunksize: time Quantity 
+    chunksize: time Quantity
                length of chunks
-    
+
     Returns
     -------
     fpeak : peak in Hz
@@ -665,8 +665,7 @@ def find_frequency_range(anas, fs, freq_range, nchunks=30, chunksize=1*pq.s):
     avg_spectrum = np.mean(Pxxpre, axis=0)
     fpeak = fpre[np.where((fpre>freq_range[0]) &
                           (fpre<freq_range[1]))][np.argmax(avg_spectrum[np.where(
-                              (fpre>freq_range[0]) & 
+                              (fpre>freq_range[0]) &
                               (fpre<freq_range[1]))])]
 
     return int(fpeak)*pq.Hz
-

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -60,6 +60,20 @@ def attach_to_cli(cli):
                   type=click.Choice(['filtfilt', 'lfilter']),
                   default='filtfilt',
                   help='Filter function. The default "filtfilt" corresponds to a forward-backward filter operation, "lfilter" a forward filter. NOTE: does not affect filtering with klusta.')
+    @click.option('--use-single-threshold',
+                  type=click.Choice([True, False]),
+                  default=True,
+                  help='Use the same threshold across channels. Default is True')
+    @click.option('--threshold-strong-std-factor',
+                  type=click.FLOAT,
+                  default=4.5,
+                  help='Strong spike detection threshold. Default is 4.5',
+                  )
+    @click.option('--threshold-weak-std-factor',
+                  type=click.FLOAT,
+                  default=2,
+                  help='Weak spike detection threshold. Default is 2',
+                  )
     @click.option('--common-ref',
                   type=click.Choice(['car', 'cmr', 'none']),
                   default='cmr',
@@ -104,6 +118,9 @@ def attach_to_cli(cli):
     def process_openephys(action_id, prb_path, pre_filter,
                           klusta_filter, filter_low, filter_high,
                           filter_order, filter_function,
+                          use_single_threshold,
+                          threshold_strong_std_factor,
+                          threshold_weak_std_factor,
                           common_ref, ground,
                           split_probe, no_local, openephys_path,
                           exdir_path, no_klusta, shutter_channel,
@@ -145,7 +162,10 @@ def attach_to_cli(cli):
                               fs=fs, klusta_filter=klusta_filter,
                               filter_low=filter_low,
                               filter_high=filter_high,
-                              filter_order=filter_order)
+                              filter_order=filter_order,
+                              use_single_threshold=use_single_threshold,
+                              threshold_strong_std_factor=threshold_strong_std_factor,
+                              threshold_weak_std_factor=threshold_weak_std_factor)
             if pre_filter:
                 anas = sig_tools.filter_analog_signals(anas, freq=[filter_low, filter_high],
                                              fs=fs, filter_type='bandpass',

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -61,8 +61,8 @@ def attach_to_cli(cli):
                   default='filtfilt',
                   help='Filter function. The default "filtfilt" corresponds to a forward-backward filter operation, "lfilter" a forward filter. NOTE: does not affect filtering with klusta.')
     @click.option('--use-single-threshold',
-                  type=click.Choice([True, False]),
-                  default=True,
+                  type=click.Choice(['True', 'False']),
+                  default='True',
                   help='Use the same threshold across channels. Default is True')
     @click.option('--threshold-strong-std-factor',
                   type=click.FLOAT,

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_openephys.py
@@ -52,6 +52,14 @@ def attach_to_cli(cli):
                   default=6000,
                   help='High cut off frequencey. Default is 6000 Hz',
                   )
+    @click.option('--filter-order',
+                  type=click.INT,
+                  default=3,
+                  help='Butterworth filter order N. Default is N=3. For acausal filters (filter type "filtfilt"), the effective filter order is N*2')
+    @click.option('--filter-function',
+                  type=click.Choice(['filtfilt', 'lfilter']),
+                  default='filtfilt',
+                  help='Filter function. The default "filtfilt" corresponds to a forward-backward filter operation, "lfilter" a forward filter. NOTE: does not affect filtering with klusta.')
     @click.option('--common-ref',
                   type=click.Choice(['car', 'cmr', 'none']),
                   default='cmr',
@@ -94,8 +102,9 @@ def attach_to_cli(cli):
                   help='TTL channel for shutter events to sync tracking',
                   )
     def process_openephys(action_id, prb_path, pre_filter,
-                          klusta_filter, filter_low,
-                          filter_high, common_ref, ground,
+                          klusta_filter, filter_low, filter_high,
+                          filter_order, filter_function,
+                          common_ref, ground,
                           split_probe, no_local, openephys_path,
                           exdir_path, no_klusta, shutter_channel,
                           no_preprocess, no_spikes, no_lfp, no_tracking):
@@ -135,10 +144,12 @@ def attach_to_cli(cli):
             sig_tools.create_klusta_prm(openephys_base, prb_path, nchan,
                               fs=fs, klusta_filter=klusta_filter,
                               filter_low=filter_low,
-                              filter_high=filter_high)
+                              filter_high=filter_high,
+                              filter_order=filter_order)
             if pre_filter:
                 anas = sig_tools.filter_analog_signals(anas, freq=[filter_low, filter_high],
-                                             fs=fs, filter_type='bandpass')
+                                             fs=fs, filter_type='bandpass',
+                                             order=filter_order, filter_function=filter_function)
             if len(ground) != 0:
                 ground = [int(g) for g in ground]
                 anas = sig_tools.ground_bad_channels(anas, ground)

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_transfer.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_transfer.py
@@ -64,7 +64,8 @@ def attach_to_cli(cli):
                   help='Name of server as named in config.yaml. Default is "nird"',
                   )
     @click.option('--override-prompts',
-                  is_flag=False,
+                  is_flag=True,
+                  default=False,
                   help='disables yes/no prompts for automated removal of files after transfer. Default is False')
     def transfer(action_id, to_local, from_local, overwrite, no_trash,
                  exclude, include, port, username,
@@ -162,13 +163,13 @@ def attach_to_cli(cli):
                 try:
                     from send2trash import send2trash
                     if override_prompts:
-                        print('send local data "' + local_data + '"to trash.')
+                        print('thrashing local data "' + local_data + '"')
                         send2trash(local_data)
                     else:
                         if action_tools.query_yes_no(
                                 'Thrash local data {}?'.format(local_data),
                                 default='no'):
-                            print('send local data "' + local_data + '"to trash.')
+                            print('thrashing local data "' + local_data + '"')
                             send2trash(local_data)
                 except Exception:
                     warnings.warn('Unable to send local data to trash')

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_transfer.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_transfer.py
@@ -63,9 +63,13 @@ def attach_to_cli(cli):
                   type=click.STRING,
                   help='Name of server as named in config.yaml. Default is "nird"',
                   )
+    @click.option('--override-prompts',
+                  is_flag=False,
+                  help='disables yes/no prompts for automated removal of files after transfer. Default is False')
     def transfer(action_id, to_local, from_local, overwrite, no_trash,
                  exclude, include, port, username,
-                 hostname, recursive, server, move):
+                 hostname, recursive, server, move,
+                 override_prompts):
         assert server in expipe.config.settings
         server_dict = expipe.config.settings.get(server)
         if len(exclude) > 0 and len(include) > 0:
@@ -157,20 +161,27 @@ def attach_to_cli(cli):
             if not no_trash and not move:
                 try:
                     from send2trash import send2trash
-                    if action_tools.query_yes_no(
-                            'Thrash local data {}?'.format(local_data),
-                            default='no'):
+                    if override_prompts:
+                        print('send local data "' + local_data + '"to trash.')
                         send2trash(local_data)
-                        print('local data "' + local_data +
-                              '" sent to trash.')
+                    else:
+                        if action_tools.query_yes_no(
+                                'Thrash local data {}?'.format(local_data),
+                                default='no'):
+                            print('send local data "' + local_data + '"to trash.')
+                            send2trash(local_data)
                 except Exception:
                     warnings.warn('Unable to send local data to trash')
             if move:
-                if action_tools.query_yes_no(
-                        'Delete local data in {}? (yes/no)?'.format(local_data),
-                        default='no'):                                    
+                if override_prompts:
                     print('Deleting "' + local_data + '".')
                     shutil.rmtree(local_data)
+                else:
+                    if action_tools.query_yes_no(
+                            'Delete local data in {}? (yes/no)?'.format(local_data),
+                            default='no'):                                    
+                        print('Deleting "' + local_data + '".')
+                        shutil.rmtree(local_data)
         else:
             raise IOError('You must choose "to-local" or "from-local"')
             ssh.close()

--- a/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_transfer.py
+++ b/expipe-plugin-cinpla/expipe_plugin_cinpla/cli_transfer.py
@@ -63,14 +63,14 @@ def attach_to_cli(cli):
                   type=click.STRING,
                   help='Name of server as named in config.yaml. Default is "nird"',
                   )
-    @click.option('--override-prompts',
+    @click.option('-y', '--yes',
                   is_flag=True,
                   default=False,
                   help='disables yes/no prompts for automated removal of files after transfer. Default is False')
     def transfer(action_id, to_local, from_local, overwrite, no_trash,
                  exclude, include, port, username,
                  hostname, recursive, server, move,
-                 override_prompts):
+                 yes):
         assert server in expipe.config.settings
         server_dict = expipe.config.settings.get(server)
         if len(exclude) > 0 and len(include) > 0:
@@ -162,7 +162,7 @@ def attach_to_cli(cli):
             if not no_trash and not move:
                 try:
                     from send2trash import send2trash
-                    if override_prompts:
+                    if yes:
                         print('thrashing local data "' + local_data + '"')
                         send2trash(local_data)
                     else:
@@ -174,7 +174,7 @@ def attach_to_cli(cli):
                 except Exception:
                     warnings.warn('Unable to send local data to trash')
             if move:
-                if override_prompts:
+                if yes:
                     print('Deleting "' + local_data + '".')
                     shutil.rmtree(local_data)
                 else:


### PR DESCRIPTION
Allows setting a few klusta prm options from command line when invoking `expipe process`:
```
  --filter-order INTEGER          Butterworth filter order N. Default is N=3.
                                  For acausal filters (filter type
                                  "filtfilt"), the effective filter order is
                                  N*2
  --filter-function [filtfilt|lfilter]
                                  Filter function. The default "filtfilt"
                                  corresponds to a forward-backward filter
                                  operation, "lfilter" a forward filter. NOTE:
                                  does not affect filtering with klusta.
  --use-single-threshold [True|False]
                                  Use the same threshold across channels.
                                  Default is True
  --threshold-strong-std-factor FLOAT
                                  Strong spike detection threshold. Default is
                                  4.5
  --threshold-weak-std-factor FLOAT
```

Adds `expipe transfer` option:
```
  --override-prompts              disables yes/no prompts for automated
                                  removal of files after transfer. Default is
                                  False
```